### PR TITLE
Fix segmentation faults/core dumps on int/string 2 char conversion

### DIFF
--- a/arduino/miflo/miflo.ino
+++ b/arduino/miflo/miflo.ino
@@ -91,7 +91,7 @@ char* string2char(String s) {
 }
 
 char* int2char(int n) {
-  char s[16];
+  static char s[16];
   itoa(n, s, 10);
   return s;
 }

--- a/arduino/miflo/miflo.ino
+++ b/arduino/miflo/miflo.ino
@@ -84,10 +84,13 @@ bool todo_done[ 4 ] = { false, false, false, false };
 char current_job_string[200] = "";
 
 char* string2char(String s) {
+  static char *p;
   if (s.length() != 0) {
-    char *p = const_cast<char*>(s.c_str());
-    return p;
+    p = const_cast<char*>(s.c_str());
+  } else {
+    *p = 0; //empty string
   }
+  return p;
 }
 
 char* int2char(int n) {
@@ -743,7 +746,7 @@ void show_upcoming_events() {
   int x = 0;
   for ( std::map<int, String>::iterator i = cache.begin(); i != cache.end(); i++ ) {
     GD.cmd_text(20, 60 + x * 20, 20, 0, string2char( format_time( i->first / 10000, (i->first / 100) % 100, i->first % 100 ) ) );
-    GD.cmd_text(80, 60 + x * 20, 20, 0, string2char(i->second));
+    GD.cmd_text(80, 60 + x * 20, 20, 0, string2char( i->second ));
     x++;
   }
 


### PR DESCRIPTION
De functies `int2char` and `string2char` geven een pointer terug die naar een variabele gedefiniëerd in de scope van de respectievelijke functie zelf verwijst. Bijgevolg bestaat deze variabele niet meer tegen dat ze gebruikt wordt (meestal in de GD library). Dit kan leiden tot core dumps indien dat stukje geheugen intussen reeds overschreven is.
Functie `string2char` geeft daarbovenop niets terug indien een lege string opgegeven wordt. In het geval van scheduled events kan het voorkomen dat de event-tekst leeg is (ok, de calender-backend zou dit mss moeten opvangen) waarop ook een core dump getriggered wordt indien de functie als parameter van een andere functie gebruikt wordt waardat een char* pointer verwacht wordt.
Dit werd hier opgelost door de variabelen static te maken en in string2char een lege char terug te geven bij een lege input-string. 