### PR TITLE
Compatibility with HUZZAH32 ESP32

### DIFF
--- a/arduino/README.md
+++ b/arduino/README.md
@@ -18,17 +18,16 @@ Je hebt ook de volgende libraries nodig:
 * [ArduinoJson](https://github.com/bblanchon/ArduinoJson) JSON library
 * [PubSubClient](https://github.com/knolleary/pubsubclient) MQTT client library
 
-In de gameduino 2/3 library moet je enkele aanpassingen doen zodat we de correcte pins van de HUZZAH aanspreken:
+In de gameduino 2/3 library moet je enkele aanpassingen doen zodat we de correcte pins van de HUZZAH of HUZZAH32 aanspreken:
 
-*  Voor de ESP8266 chip: Voer in het bestand `transports/wiring.h`
-	
+* Voor de ESP8266 chip: Voer in het bestand `transports/wiring.h`
 	```
 	#define D8  0
 	#define D9  16
 	```
 	toe net voor de lijn `#define CS D8`.
-*  Voor de ESP32 chip: Voer in het bestand `transports/wiring.h`
-
+* Voor de ESP32 chip: 
+  * Voer in het bestand `transports/wiring.h`
 	```
 	#define D8  15
 	#define D9  32 
@@ -41,7 +40,17 @@ In de gameduino 2/3 library moet je enkele aanpassingen doen zodat we de correct
 	```
 	#define CS 15
 	```
-* Zoek in bestand `GD2.h` naar `#define L2` en `#define L4` en comment deze lijnen uit.
+  * Wijzig in het bestand `GD2.h`:
+  	```
+	#elif defined(ESP32)
+	#define SD_PIN        13
+	```
+	in
+	```
+	#elif defined(ESP32)
+	#define SD_PIN        32
+	```
+* (dit lijkt niet nodig: Zoek in bestand `GD2.h` naar `#define L2` en `#define L4` en comment deze lijnen uit.)
 
 
 De arduino code gaat ervanuit dat je de geconverteerde [assets](../assets) mee op de sd kaart gezet hebt.

--- a/arduino/README.md
+++ b/arduino/README.md
@@ -16,17 +16,18 @@ Je hebt ook de volgende libraries nodig:
 * arduino EEPROM library
 * [RTC](https://github.com/adafruit/RTClib) library.
 * [ArduinoJson](https://github.com/bblanchon/ArduinoJson)
+* [PubSubClient](https://github.com/knolleary/pubsubclient) MQTT client library
 
-In de gameduino library moet je enkele aanpassingen doen in de GD2.file:
+In de gameduino library moet je enkele aanpassingen doen in de GD2-files:
 
-*  Voeg
+*  Voeg in transports/wiring.h
 	
 	```
 	#define D8  0
 	#define D9  16
 	```
 	toe net voor de lijn `#define CS D8`.
-* Zoek naar `#define L2` en `#define L4` en comment deze lijnen.
+* Zoek in GD2.h naar `#define L2` en `#define L4` en comment deze lijnen.
 
 
 De arduino code gaat ervanuit dat je de geconverteerde [assets](../assets) mee op de sd kaart gezet hebt.

--- a/arduino/README.md
+++ b/arduino/README.md
@@ -27,13 +27,20 @@ In de gameduino library moet je enkele aanpassingen doen in de GD2-files:
 	#define D9  16
 	```
 	toe net voor de lijn `#define CS D8`.
-* Voor de ESP32 chip: Voer in de transports/wiring.h
-        ```
+*  Voor de ESP32 chip: Voer in de transports/wiring.h
+
+	```
         #define D8  15
         #define D9  32 
-        ```
-        toe net na de lijn `#elif  defined(ESP32)`.
-        Wijzig vervolgens de lijn `#define CS 12` naar `#define CS 15`
+	```
+	toe net na de lijn `#elif  defined(ESP32)` en wijzig de lijn 
+	```
+	#define CS 12
+	```
+	in 
+	```
+	#define CS 15
+	```
 * Zoek in GD2.h naar `#define L2` en `#define L4` en comment deze lijnen.
 
 

--- a/arduino/README.md
+++ b/arduino/README.md
@@ -6,7 +6,7 @@ Bekijk in de [hardware](../hardware) folder van dit project de volledige hardwar
 
 ## Configuratie en setup
 
-Alle details over de Adafruit Feather [HUZZAH ESP8266](https://learn.adafruit.com/adafruit-feather-huzzah-esp8266/overview) of [HUZZAH32 ESP32]((https://learn.adafruit.com/adafruit-feather-huzzah32-esp32/overview) staan op [de site van adafruit](https://learn.adafruit.com/search?q=HUZZAH).
+Alle details over de Adafruit Feather [HUZZAH ESP8266](https://learn.adafruit.com/adafruit-feather-huzzah-esp8266/overview) of [HUZZAH32 ESP32](https://learn.adafruit.com/adafruit-feather-huzzah32-esp32/overview) staan op [de site van adafruit](https://learn.adafruit.com/search?q=HUZZAH).
 
 Kopiëer het bestand `settings_example.h` naar `settings.h` en vul alle parameters in.
 

--- a/arduino/README.md
+++ b/arduino/README.md
@@ -1,37 +1,37 @@
 # Arduino code voor de MiFlo
 
-Deze code is geschreven voor een [Adafruit Feather HUZZAH ESP8266](https://learn.adafruit.com/adafruit-feather-huzzah-esp8266) in combinatie met een [gameduino touchscreen](https://www.watterott.com/en/Gameduino-3). 
+Deze code is geschreven voor een [Adafruit Feather HUZZAH ESP8266](https://learn.adafruit.com/adafruit-feather-huzzah-esp8266) of [Adafruit Feather HUZZAH32](https://learn.adafruit.com/adafruit-huzzah32-esp32-feather) in combinatie met een [gameduino 3 touchscreen](https://www.watterott.com/en/Gameduino-3). 
 
 Bekijk in de [hardware](../hardware) folder van dit project de volledige hardware lijst.
 
 ## Configuratie en setup
 
-Alle details over de Adafruit Feather HUZZAH ESP8266 staan op [de site van adafruit](https://learn.adafruit.com/adafruit-feather-huzzah-esp8266/using-arduino-ide).
+Alle details over de Adafruit Feather [HUZZAH ESP8266](https://learn.adafruit.com/adafruit-feather-huzzah-esp8266/overview) of [HUZZAH32 ESP32]((https://learn.adafruit.com/adafruit-feather-huzzah32-esp32/overview) staan op [de site van adafruit](https://learn.adafruit.com/search?q=HUZZAH).
 
 Kopiëer het bestand `settings_example.h` naar `settings.h` en vul alle parameters in.
 
 Je hebt ook de volgende libraries nodig:
 
-* [gameduino](https://github.com/jamesbowman/gd2-lib)
+* [gd2-lib](https://github.com/jamesbowman/gd2-lib) Gameduino 2/3 library
 * arduino EEPROM library
-* [RTC](https://github.com/adafruit/RTClib) library.
-* [ArduinoJson](https://github.com/bblanchon/ArduinoJson)
+* [RTClib](https://github.com/adafruit/RTClib) RTC library.
+* [ArduinoJson](https://github.com/bblanchon/ArduinoJson) JSON library
 * [PubSubClient](https://github.com/knolleary/pubsubclient) MQTT client library
 
-In de gameduino library moet je enkele aanpassingen doen in de GD2-files:
+In de gameduino 2/3 library moet je enkele aanpassingen doen zodat we de correcte pins van de HUZZAH aanspreken:
 
-*  Voor de ESP8266 chip: Voer in transports/wiring.h
+*  Voor de ESP8266 chip: Voer in het bestand `transports/wiring.h`
 	
 	```
 	#define D8  0
 	#define D9  16
 	```
 	toe net voor de lijn `#define CS D8`.
-*  Voor de ESP32 chip: Voer in de transports/wiring.h
+*  Voor de ESP32 chip: Voer in het bestand `transports/wiring.h`
 
 	```
-        #define D8  15
-        #define D9  32 
+	#define D8  15
+	#define D9  32 
 	```
 	toe net na de lijn `#elif  defined(ESP32)` en wijzig de lijn 
 	```
@@ -41,7 +41,7 @@ In de gameduino library moet je enkele aanpassingen doen in de GD2-files:
 	```
 	#define CS 15
 	```
-* Zoek in GD2.h naar `#define L2` en `#define L4` en comment deze lijnen.
+* Zoek in bestand `GD2.h` naar `#define L2` en `#define L4` en comment deze lijnen uit.
 
 
 De arduino code gaat ervanuit dat je de geconverteerde [assets](../assets) mee op de sd kaart gezet hebt.

--- a/arduino/README.md
+++ b/arduino/README.md
@@ -20,13 +20,20 @@ Je hebt ook de volgende libraries nodig:
 
 In de gameduino library moet je enkele aanpassingen doen in de GD2-files:
 
-*  Voeg in transports/wiring.h
+*  Voor de ESP8266 chip: Voer in transports/wiring.h
 	
 	```
 	#define D8  0
 	#define D9  16
 	```
 	toe net voor de lijn `#define CS D8`.
+* Voor de ESP32 chip: Voer in de transports/wiring.h
+        ```
+        #define D8  15
+        #define D9  32 
+        ```
+        toe net na de lijn `#elif  defined(ESP32)`.
+        Wijzig vervolgens de lijn `#define CS 12` naar `#define CS 15`
 * Zoek in GD2.h naar `#define L2` en `#define L4` en comment deze lijnen.
 
 

--- a/arduino/miflo/miflo.ino
+++ b/arduino/miflo/miflo.ino
@@ -23,10 +23,12 @@ int noteDurations[] = {
 
 #include "settings.h"
 
-#if defined(ESP8266)
+#if defined(ESP8266)     //HUZZAH
 #include <ESP8266WiFi.h>
-#elif defined(ESP32)
+#define AMP_SD_PIN 15
+#elif defined(ESP32)    //HUZZAH32
 #include <WiFi.h>
+#define AMP_SD_PIN 16
 #endif
 WiFiClient espClient;
 
@@ -152,7 +154,7 @@ int samplefreqs[20] = {G_COOL_FREQ, G_FORMID_FREQ, G_MACHTI_FREQ, G_STIEVA_FREQ,
 int samplelengths[20] = {G_COOL_LENGTH, G_FORMID_LENGTH, G_MACHTI_LENGTH, G_STIEVA_LENGTH, G_WOEW_LENGTH, G_DDUIM2_LENGTH, G_GOED_LENGTH, G_SUPER_LENGTH, G_WOOP_LENGTH, G_ALLEZ_LENGTH, G_DEMAX_LENGTH, G_GOEDZO_LENGTH, G_PRIMA_LENGTH, G_TSJING_LENGTH, G_ZOGOED_LENGTH, G_BOL_LENGTH, G_FANTAS_LENGTH, G_HOPLA_LENGTH, G_SCOOL_LENGTH, G_WIII_LENGTH};
 
 void sample() {
-  digitalWrite(15, HIGH);
+  digitalWrite(AMP_SD_PIN, HIGH);
   GD.play(UNMUTE);
   uint32_t base, len, freq;
   int i = rand() % 20;
@@ -162,11 +164,11 @@ void sample() {
   GD.sample(base, len, freq, ADPCM_SAMPLES);
   delay(2000 * len / freq);
   GD.play(MUTE);
-  digitalWrite(15, LOW);
+  digitalWrite(AMP_SD_PIN, LOW);
 }
 
 void jingle( int n = 0 ) {
-  digitalWrite(15, HIGH);
+  digitalWrite(AMP_SD_PIN, HIGH);
   if ( n == 0 ) {
     GD.play( MUSICBOX, 60 );
     delay(250);
@@ -190,7 +192,7 @@ void jingle( int n = 0 ) {
     delay(500);
     GD.play( MUTE );
   }
-  digitalWrite(15, LOW);
+  digitalWrite(AMP_SD_PIN, LOW);
 }
 
 #include <map>
@@ -383,8 +385,8 @@ void load_jpgs()
 void setup() {
   Serial.begin(115200);
 
-  pinMode( 15, OUTPUT );
 
+  pinMode( AMP_SD_PIN, OUTPUT );
   Serial.println("Starting gameduino ...");
   GD.begin(GD_STORAGE);
   GD.play( MUTE );

--- a/arduino/miflo/miflo.ino
+++ b/arduino/miflo/miflo.ino
@@ -23,7 +23,11 @@ int noteDurations[] = {
 
 #include "settings.h"
 
+#if defined(ESP8266)
 #include <ESP8266WiFi.h>
+#elif defined(ESP32)
+#include <WiFi.h>
+#endif
 WiFiClient espClient;
 
 #include <PubSubClient.h>

--- a/hardware/README.md
+++ b/hardware/README.md
@@ -4,6 +4,7 @@ De hardware in de MiFlo is opgebouwd op eenvoudig verkrijgbare modules:
 
 * In het originele project wordt een [Adafruit Feather HUZZAH](https://learn.adafruit.com/adafruit-feather-huzzah-esp8266) gebruikt als de "Arduino". Deze bevat een ESP8266 chip waarmee we ook WiFi kunnen gebruiken. Zijn opvolger, de [Adafruit Feather HUZZAH32](https://learn.adafruit.com/adafruit-huzzah32-esp32-feather) kan echter ook gebruikt worden. Deze is een pak krachtiger en bovendien een beetje zuiniger in verbruik.
 * De [Gameduino 3](http://excamera.com/sphinx/gameduino3/) is een touchscreen dat je makkelijk op een Arduino kan monteren en aansturen. Het kan ook geluiden of filmpjes spelen van een SD kaart. Bijvoorbeeld [hier te koop](https://www.watterott.com/de/Gameduino-3).
+  * Een micro SD kaart voor de [assets](../assets) van het MiFlo programma. Let op dat je betrouwbare SD-kaart koopt, want de gameduino kan problemen hebben met goedkopere of witte merken. Met een SanDisk of Kingston kan je normaal weinig mis doen.
 * Met een [RTC breakout board](https://www.adafruit.com/product/3295) kunnen we de tijd bijhouden als de MiFlo geen stroom heeft.
 * Een [geluidsversterker](https://www.adafruit.com/product/1752) zorgt ervoor dat de audio krachtig genoeg uit de speakers komt.
 * We bouwden alles in een [SoundLogic draagbare speaker](https://www.action.com/nl-be/p/soundlogic-draagbare-speaker/) van den Action.

--- a/hardware/README.md
+++ b/hardware/README.md
@@ -2,7 +2,7 @@
 
 De hardware in de MiFlo is opgebouwd op eenvoudig verkrijgbare modules:
 
-* Een [Adafruit Feather HUZZAH](https://learn.adafruit.com/adafruit-feather-huzzah-esp8266) wordt gebruikt als de "Arduino". Deze bevat een ESP8266 chip waarmee we ook WiFi kunnen gebruiken
+* In het originele project wordt een [Adafruit Feather HUZZAH](https://learn.adafruit.com/adafruit-feather-huzzah-esp8266) gebruikt als de "Arduino". Deze bevat een ESP8266 chip waarmee we ook WiFi kunnen gebruiken. Zijn opvolger, de [Adafruit Feather HUZZAH32](https://learn.adafruit.com/adafruit-huzzah32-esp32-feather) kan echter ook gebruikt worden. Deze is een pak krachtiger en bovendien een beetje zuiniger in verbruik.
 * De [Gameduino 3](http://excamera.com/sphinx/gameduino3/) is een touchscreen dat je makkelijk op een Arduino kan monteren en aansturen. Het kan ook geluiden of filmpjes spelen van een SD kaart. Bijvoorbeeld [hier te koop](https://www.watterott.com/de/Gameduino-3).
 * Met een [RTC breakout board](https://www.adafruit.com/product/3295) kunnen we de tijd bijhouden als de MiFlo geen stroom heeft.
 * Een [geluidsversterker](https://www.adafruit.com/product/1752) zorgt ervoor dat de audio krachtig genoeg uit de speakers komt.


### PR DESCRIPTION
Aanpassingen voor compatibiliteit met de Adafruit HUZZAH32.
+ vermelden PubSubClient library in software requirements
+ vermelden vereiste SD card in hardware requirements